### PR TITLE
Persist built container images to local repository

### DIFF
--- a/tasks/containers/Makefile
+++ b/tasks/containers/Makefile
@@ -49,7 +49,7 @@ docker/aws_ecr_login:
 .PHONY: docker/build
 docker/build : docker/check-env-vars
 	@echo "Building with CONTAINER_REGISTRY=$(CONTAINER_REGISTRY), CONTAINER_IMAGE_NAME=$(CONTAINER_IMAGE_NAME), CONTAINER_IMAGE_VERSION=$(CONTAINER_IMAGE_VERSION)"
-	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) .
+	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --load .
 
 .PHONY: docker/push
 docker/push : docker/build


### PR DESCRIPTION
Previously, this would only end up in the build cache and so `make docker/build` didn't actually build a usable container. This ensures the containers are built and pushed into the local image repository.