### PR TITLE
moving docker build arch to a var

### DIFF
--- a/tasks/containers/Makefile
+++ b/tasks/containers/Makefile
@@ -14,6 +14,7 @@ FIND ?= find
 # Variables
 
 CONFTEST_POLICY_DIRECTORIES ?= $(MODULE_DIR)/policy
+DOCKER_BULD_ARCH ?= linux/amd64,linux/arm64
 
 # Functions
 
@@ -49,11 +50,11 @@ docker/aws_ecr_login:
 .PHONY: docker/build
 docker/build : docker/check-env-vars
 	@echo "Building with CONTAINER_REGISTRY=$(CONTAINER_REGISTRY), CONTAINER_IMAGE_NAME=$(CONTAINER_IMAGE_NAME), CONTAINER_IMAGE_VERSION=$(CONTAINER_IMAGE_VERSION)"
-	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --load .
+	$(DOCKER) buildx build --platform $(DOCKER_BULD_ARCH) $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --load .
 
 .PHONY: docker/push
 docker/push : docker/build
-	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --push .
+	$(DOCKER) buildx build --platform $(DOCKER_BULD_ARCH) $(BUILD_ARGS) -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE_NAME):$(CONTAINER_IMAGE_VERSION) --push .
 
 .PHONY: check
 check::


### PR DESCRIPTION
- Moving docker build arch type to a var to be set by an env var. 